### PR TITLE
Fix NaN compare in FloatValidator

### DIFF
--- a/data/fpe_wa2.out
+++ b/data/fpe_wa2.out
@@ -1,0 +1,5 @@
+Case #1: 1
+Case #2: NaN
+Case #3: NaN
+Case #4: NaN
+Case #5: NaN

--- a/src/FloatValidator.java
+++ b/src/FloatValidator.java
@@ -32,7 +32,7 @@ public class FloatValidator extends Validator
 
 			if (o == null && !out_tokens[i].equals(ans_tokens[i]))
 				return false;
-			if (o != null && Math.abs(o - a) > eps * Math.max(1, Math.abs(a)))
+			if (o != null && !(Math.abs(o - a) <= eps * Math.max(1, Math.abs(a))))
 				return false;
 		}
 		return true;


### PR DESCRIPTION
A string "NaN" can be parsed into a constant double value NaN, which makes (Math.abs(o - a) > eps \* Math.max(1, Math.abs(a))) always equal to false.
For example, data/fpe_wa2.out can pass the test.
